### PR TITLE
bugfix: rename the library in test

### DIFF
--- a/tests/test_group_info.py
+++ b/tests/test_group_info.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pyticcom import GroupInfo, PAPP_DESCRIPTION, UNIT_VA
+from pytictri import GroupInfo, PAPP_DESCRIPTION, UNIT_VA
 
 
 class TestGroupInfo(unittest.TestCase):

--- a/tests/test_teleinfo.py
+++ b/tests/test_teleinfo.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest import mock
 
-from pyticcom import Teleinfo, GroupInfo
+from pytictri import Teleinfo, GroupInfo
 
 
 class TestTeleinfo(unittest.TestCase):


### PR DESCRIPTION
The test wasn't rename when you forked the library